### PR TITLE
upgrade django cache url to 3.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ defusedxml==0.6.0; python_version >= "3.6" and python_full_version < "3.0.0" or 
 dj-database-url==0.5.0
 dj-email-url==1.0.1
 django-appconf==1.0.4
-django-cache-url==3.1.2
+django-cache-url==3.2.0
 django-countries==6.1.3
 django-filter==2.4.0; python_version >= "3.5"
 django-js-asset==1.2.2; python_version >= "3.5"


### PR DESCRIPTION
I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
